### PR TITLE
Fix the path for removing observability using infra.down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,6 @@ infra.up:
 
 infra.down:
 	@podman kube down resources/dev.yml
-	@podman kube down resources/prometheus.yml
+	@podman kube down resources/observability.yml
 
 .PHONY: vendor build run

--- a/dashboard/grafana.json
+++ b/dashboard/grafana.json
@@ -1,4 +1,4 @@
-
+{
   "annotations": {
     "list": [
       {

--- a/samples/producer/main.go
+++ b/samples/producer/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	flag.StringVar(&inventory, "inventory", "", "")
 	flag.StringVar(&sourceID, "source_id", uuid.NewString(), "")
-	flag.StringVar(&timeout, "timetout", "1s", "")
+	flag.StringVar(&timeout, "timeout", "1s", "")
 	flag.BoolVar(&oneShot, "oneshot", false, "send only one message")
 	flag.Parse()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Grafana dashboard with metrics for message rates, processing success, latency percentiles, and topic distribution.

* **Bug Fixes**
  * Fixed a CLI flag name for the producer so the timeout option works as expected.

* **Chores**
  * Updated infrastructure shutdown to properly stop observability services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-event-streamer/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->