### PR TITLE
Fix consumer shutdown hang with BlockRebalanceOnPoll

### DIFF
--- a/internal/datastore/kafka/consumer.go
+++ b/internal/datastore/kafka/consumer.go
@@ -111,6 +111,6 @@ func (c *Consumer) Close(_ context.Context) error {
 	if c.done != nil {
 		<-c.done
 	}
-	c.cl.Close()
+	c.cl.CloseAllowingRebalance()
 	return nil
 }


### PR DESCRIPTION
Use CloseAllowingRebalance() instead of Close() to prevent shutdown
deadlock. Since we configure BlockRebalanceOnPoll(), the standard
Close() blocks indefinitely waiting for a rebalance that never
completes. CloseAllowingRebalance() overrides the block to allow
the final revoke event and clean group exit.

Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kafka consumer shutdown handling to support graceful rebalancing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-event-streamer/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->