### PR TITLE
Add action_type field to user action entities

### DIFF
--- a/internal/entity/user_action.go
+++ b/internal/entity/user_action.go
@@ -8,6 +8,7 @@ import (
 
 type ShareAssessmentResult struct {
 	ID           string `json:"-"`
+	ActionType   string `json:"action_type"`
 	Username     string `json:"username"`
 	AssessmentID string `json:"assessment_id"`
 	PartnerID    string `json:"partner_id"`
@@ -16,6 +17,7 @@ type ShareAssessmentResult struct {
 
 type UnshareAssessmentResult struct {
 	ID           string `json:"-"`
+	ActionType   string `json:"action_type"`
 	Username     string `json:"username"`
 	AssessmentID string `json:"assessment_id"`
 	Timestamp    string `json:"timestamp"`
@@ -23,6 +25,7 @@ type UnshareAssessmentResult struct {
 
 type SizingRequestedResult struct {
 	ID           string `json:"-"`
+	ActionType   string `json:"action_type"`
 	Username     string `json:"username"`
 	AssessmentID string `json:"assessment_id"`
 	Timestamp    string `json:"timestamp"`
@@ -30,6 +33,7 @@ type SizingRequestedResult struct {
 
 type ComplexityEstimatedResult struct {
 	ID           string `json:"-"`
+	ActionType   string `json:"action_type"`
 	Username     string `json:"username"`
 	AssessmentID string `json:"assessment_id"`
 	Timestamp    string `json:"timestamp"`
@@ -37,28 +41,32 @@ type ComplexityEstimatedResult struct {
 
 type TimeEstimatedResult struct {
 	ID           string `json:"-"`
+	ActionType   string `json:"action_type"`
 	Username     string `json:"username"`
 	AssessmentID string `json:"assessment_id"`
 	Timestamp    string `json:"timestamp"`
 }
 
 type OVADownloadedResult struct {
-	ID        string `json:"-"`
-	Username  string `json:"username"`
-	SourceID  string `json:"source_id"`
-	Timestamp string `json:"timestamp"`
+	ID         string `json:"-"`
+	ActionType string `json:"action_type"`
+	Username   string `json:"username"`
+	SourceID   string `json:"source_id"`
+	Timestamp  string `json:"timestamp"`
 }
 
 type VisitedResult struct {
-	ID        string `json:"-"`
-	Username  string `json:"username"`
-	OrgID     string `json:"org_id"`
-	Timestamp string `json:"timestamp"`
+	ID         string `json:"-"`
+	ActionType string `json:"action_type"`
+	Username   string `json:"username"`
+	OrgID      string `json:"org_id"`
+	Timestamp  string `json:"timestamp"`
 }
 
 func NewShareAssessmentResult(username, assessmentID, partnerID string, timestamp time.Time) ShareAssessmentResult {
 	return ShareAssessmentResult{
 		ID:           uuid.New().String(),
+		ActionType:   "assessment_shared",
 		Username:     username,
 		AssessmentID: assessmentID,
 		PartnerID:    partnerID,
@@ -69,6 +77,7 @@ func NewShareAssessmentResult(username, assessmentID, partnerID string, timestam
 func NewUnshareAssessmentResult(username, assessmentID string, timestamp time.Time) UnshareAssessmentResult {
 	return UnshareAssessmentResult{
 		ID:           uuid.New().String(),
+		ActionType:   "assessment_unshared",
 		Username:     username,
 		AssessmentID: assessmentID,
 		Timestamp:    timestamp.Format(time.RFC3339),
@@ -78,6 +87,7 @@ func NewUnshareAssessmentResult(username, assessmentID string, timestamp time.Ti
 func NewSizingRequestedResult(username, assessmentID string, timestamp time.Time) SizingRequestedResult {
 	return SizingRequestedResult{
 		ID:           uuid.New().String(),
+		ActionType:   "sizing_requested",
 		Username:     username,
 		AssessmentID: assessmentID,
 		Timestamp:    timestamp.Format(time.RFC3339),
@@ -87,6 +97,7 @@ func NewSizingRequestedResult(username, assessmentID string, timestamp time.Time
 func NewComplexityEstimatedResult(username, assessmentID string, timestamp time.Time) ComplexityEstimatedResult {
 	return ComplexityEstimatedResult{
 		ID:           uuid.New().String(),
+		ActionType:   "complexity_estimated",
 		Username:     username,
 		AssessmentID: assessmentID,
 		Timestamp:    timestamp.Format(time.RFC3339),
@@ -96,6 +107,7 @@ func NewComplexityEstimatedResult(username, assessmentID string, timestamp time.
 func NewTimeEstimatedResult(username, assessmentID string, timestamp time.Time) TimeEstimatedResult {
 	return TimeEstimatedResult{
 		ID:           uuid.New().String(),
+		ActionType:   "time_estimated",
 		Username:     username,
 		AssessmentID: assessmentID,
 		Timestamp:    timestamp.Format(time.RFC3339),
@@ -104,18 +116,20 @@ func NewTimeEstimatedResult(username, assessmentID string, timestamp time.Time) 
 
 func NewOVADownloadedResult(username, sourceID string, timestamp time.Time) OVADownloadedResult {
 	return OVADownloadedResult{
-		ID:        uuid.New().String(),
-		Username:  username,
-		SourceID:  sourceID,
-		Timestamp: timestamp.Format(time.RFC3339),
+		ID:         uuid.New().String(),
+		ActionType: "ova_downloaded",
+		Username:   username,
+		SourceID:   sourceID,
+		Timestamp:  timestamp.Format(time.RFC3339),
 	}
 }
 
 func NewVisitedResult(username, orgID string, timestamp time.Time) VisitedResult {
 	return VisitedResult{
-		ID:        orgID + "_" + username + "_" + timestamp.Format("20060102"),
-		Username:  username,
-		OrgID:     orgID,
-		Timestamp: timestamp.Format(time.RFC3339),
+		ID:         orgID + "_" + username + "_" + timestamp.Format("20060102"),
+		ActionType: "visited",
+		Username:   username,
+		OrgID:      orgID,
+		Timestamp:  timestamp.Format(time.RFC3339),
 	}
 }


### PR DESCRIPTION
## Summary
- Several user action types (`sizing_requested`, `complexity_estimated`, `time_estimated`, `assessment_unshared`) produce identical JSON documents (`username`, `assessment_id`, `timestamp`), making them indistinguishable once written to the `user_action` ES index
- Added an `action_type` field to all 7 user action entity structs, set automatically in each constructor to match the dispatcher key suffix (e.g. `"sizing_requested"`, `"visited"`)
- No changes needed to writers or processors — the field is picked up by the existing `json.Marshal` path
