### PR TITLE
Move pipeline registration responsibility from Dispatcher to Manager

### DIFF
--- a/internal/pipeline/dispatcher.go
+++ b/internal/pipeline/dispatcher.go
@@ -2,23 +2,8 @@ package pipeline
 
 import (
 	"context"
-	"github.com/kubev2v/migration-event-streamer/internal/datastore/elastic"
 	"github.com/kubev2v/migration-event-streamer/internal/entity"
-	"github.com/kubev2v/migration-event-streamer/internal/processors"
 	"go.uber.org/zap"
-)
-
-const (
-	AssessmentCreated         = "assessment.created"
-	AssessmentDeleted         = "assessment.deleted"
-	PartnerCustomerUpdated    = "partner_customer.updated"
-	UserActionShared          = "user_action.assessment_shared"
-	UserActionUnshared        = "user_action.assessment_unshared"
-	UserActionSizingRequested = "user_action.sizing_requested"
-	UserActionComplexity      = "user_action.complexity_estimated"
-	UserActionTimeEstimated   = "user_action.time_estimated"
-	UserActionOVADownloaded   = "user_action.ova_downloaded"
-	UserActionVisited         = "user_action.visited"
 )
 
 type PipelineStarter interface {
@@ -104,23 +89,6 @@ func (d *Dispatcher) Start(ctx context.Context) <-chan struct{} {
 	return done
 }
 
-func (d *Dispatcher) InitAllPipelines(w elastic.Writer) {
-	registerPipeline(d, AssessmentCreated, processors.AssessmentCreatedProcessor, w.Assessment().WriteCreated)
-	registerPipeline(d, AssessmentDeleted, processors.AssessmentDeletedProcessor, w.Assessment().WriteCascadeDelete)
-	registerPipeline(d, UserActionVisited, processors.VisitedProcessor, w.UserAction().WriteVisited)
-	registerPipeline(d, PartnerCustomerUpdated, processors.PartnerCustomerProcessor, w.PartnerCustomer().Write)
-	registerPipeline(d, UserActionShared, processors.ShareAssessmentProcessor, w.UserAction().WriteShareAssessment)
-	registerPipeline(d, UserActionUnshared, processors.UnshareAssessmentProcessor, w.UserAction().WriteUnshareAssessment)
-	registerPipeline(d, UserActionSizingRequested, processors.SizingRequestedProcessor, w.UserAction().WriteSizingRequested)
-	registerPipeline(d, UserActionComplexity, processors.ComplexityEstimatedProcessor, w.UserAction().WriteComplexityEstimated)
-	registerPipeline(d, UserActionTimeEstimated, processors.TimeEstimatedProcessor, w.UserAction().WriteTimeEstimated)
-	registerPipeline(d, UserActionOVADownloaded, processors.OVADownloadedProcessor, w.UserAction().WriteOVADownloaded)
-}
-
-func registerPipeline[T any, S any](d *Dispatcher, name string, process Processor[T, S], write WriteFn[S]) {
-	input := make(chan entity.PipelineJob)
-	d.pipelines[name] = &pipelineEntry{
-		input:    input,
-		pipeline: NewPipeline(name, process, write, input, d.errors).WithRetry().WithObservability().WithRecovery(),
-	}
+func (d *Dispatcher) Register(name string, input chan entity.PipelineJob, pipeline PipelineStarter) {
+	d.pipelines[name] = &pipelineEntry{input: input, pipeline: pipeline}
 }

--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -6,7 +6,21 @@ import (
 
 	"github.com/kubev2v/migration-event-streamer/internal/datastore/elastic"
 	"github.com/kubev2v/migration-event-streamer/internal/entity"
+	"github.com/kubev2v/migration-event-streamer/internal/processors"
 	"go.uber.org/zap"
+)
+
+const (
+	AssessmentCreated         = "assessment.created"
+	AssessmentDeleted         = "assessment.deleted"
+	PartnerCustomerUpdated    = "partner_customer.updated"
+	UserActionShared          = "user_action.assessment_shared"
+	UserActionUnshared        = "user_action.assessment_unshared"
+	UserActionSizingRequested = "user_action.sizing_requested"
+	UserActionComplexity      = "user_action.complexity_estimated"
+	UserActionTimeEstimated   = "user_action.time_estimated"
+	UserActionOVADownloaded   = "user_action.ova_downloaded"
+	UserActionVisited         = "user_action.visited"
 )
 
 type Consumer interface {
@@ -64,5 +78,19 @@ func (m *Manager) Wait() {
 }
 
 func (m *Manager) InitAllPipelines(w elastic.Writer) {
-	m.dispatcher.InitAllPipelines(w)
+	registerPipeline(m.dispatcher, m.errorCh, AssessmentCreated, processors.AssessmentCreatedProcessor, w.Assessment().WriteCreated)
+	registerPipeline(m.dispatcher, m.errorCh, AssessmentDeleted, processors.AssessmentDeletedProcessor, w.Assessment().WriteCascadeDelete)
+	registerPipeline(m.dispatcher, m.errorCh, UserActionVisited, processors.VisitedProcessor, w.UserAction().WriteVisited)
+	registerPipeline(m.dispatcher, m.errorCh, PartnerCustomerUpdated, processors.PartnerCustomerProcessor, w.PartnerCustomer().Write)
+	registerPipeline(m.dispatcher, m.errorCh, UserActionShared, processors.ShareAssessmentProcessor, w.UserAction().WriteShareAssessment)
+	registerPipeline(m.dispatcher, m.errorCh, UserActionUnshared, processors.UnshareAssessmentProcessor, w.UserAction().WriteUnshareAssessment)
+	registerPipeline(m.dispatcher, m.errorCh, UserActionSizingRequested, processors.SizingRequestedProcessor, w.UserAction().WriteSizingRequested)
+	registerPipeline(m.dispatcher, m.errorCh, UserActionComplexity, processors.ComplexityEstimatedProcessor, w.UserAction().WriteComplexityEstimated)
+	registerPipeline(m.dispatcher, m.errorCh, UserActionTimeEstimated, processors.TimeEstimatedProcessor, w.UserAction().WriteTimeEstimated)
+	registerPipeline(m.dispatcher, m.errorCh, UserActionOVADownloaded, processors.OVADownloadedProcessor, w.UserAction().WriteOVADownloaded)
+}
+
+func registerPipeline[T any, S any](d *Dispatcher, errors chan<- entity.PipelineError, name string, process Processor[T, S], write WriteFn[S]) {
+	input := make(chan entity.PipelineJob)
+	d.Register(name, input, NewPipeline(name, process, write, input, errors).WithRetry().WithObservability().WithRecovery())
 }


### PR DESCRIPTION
The Dispatcher now exposes a simple Register method instead of owning pipeline creation. The Manager creates and wires pipelines via a generic registerPipeline helper, giving it explicit control over the wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded event handling to cover more assessment and user activity updates.
  * Improved pipeline registration so event processing can be configured more flexibly.

* **Bug Fixes**
  * Streamlined pipeline startup to reduce setup issues and improve reliability during event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->