### PR TITLE
ECOPROJECT-4880: Implement retry mechanism for pipeline processing

### DIFF
--- a/internal/pipeline/manager.go
+++ b/internal/pipeline/manager.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/kubev2v/migration-event-streamer/internal/datastore/elastic"
 	"github.com/kubev2v/migration-event-streamer/internal/entity"
@@ -11,6 +12,9 @@ import (
 )
 
 const (
+	defaultMaxRetries = 3
+	defaultRetryDelay = 1000 * time.Millisecond
+
 	AssessmentCreated         = "assessment.created"
 	AssessmentDeleted         = "assessment.deleted"
 	PartnerCustomerUpdated    = "partner_customer.updated"
@@ -92,5 +96,5 @@ func (m *Manager) InitAllPipelines(w elastic.Writer) {
 
 func registerPipeline[T any, S any](d *Dispatcher, errors chan<- entity.PipelineError, name string, process Processor[T, S], write WriteFn[S]) {
 	input := make(chan entity.PipelineJob)
-	d.Register(name, input, NewPipeline(name, process, write, input, errors).WithRetry().WithObservability().WithRecovery())
+	d.Register(name, input, NewPipeline(name, process, write, input, errors).WithRetry(defaultMaxRetries, defaultRetryDelay).WithObservability().WithRecovery())
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -3,7 +3,9 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"runtime/debug"
+	"time"
 
 	"github.com/kubev2v/migration-event-streamer/internal/entity"
 	"go.uber.org/zap"
@@ -66,12 +68,45 @@ func (p *Pipeline[T, S]) Start(ctx context.Context) <-chan struct{} {
 	return done
 }
 
-func (p *Pipeline[T, S]) WithRetry() *Pipeline[T, S] {
+func (p *Pipeline[T, S]) WithRetry(maxRetries int, baseDelay time.Duration) *Pipeline[T, S] {
 	previous := p.handle
 	p.handle = func(ctx context.Context, input T) error {
-		// TODO add retry function
-		return previous(ctx, input)
+		var err error
+		delay := baseDelay
+		for attempt := range maxRetries + 1 {
+			if err = previous(ctx, input); err == nil {
+				return nil
+			}
+
+			if attempt == maxRetries {
+				break
+			}
+
+			zap.S().Warnw("pipeline handler failed, retrying",
+				"pipeline", p.name,
+				"attempt", attempt+1,
+				"maxRetries", maxRetries,
+				"error", err,
+			)
+
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+
+			if delay > time.Duration(math.MaxInt64/2) {
+				delay = time.Duration(math.MaxInt64)
+				continue
+			}
+			delay *= 2
+		}
+
+		return err
 	}
+
 	return p
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -260,6 +260,130 @@ var _ = Describe("Pipeline", func() {
 		})
 	})
 
+	Describe("WithRetry", func() {
+		var (
+			ctx       context.Context
+			cancel    context.CancelFunc
+			input     chan entity.PipelineJob
+			errs      chan entity.PipelineError
+			getErrors func() []entity.PipelineError
+		)
+
+		BeforeEach(func() {
+			ctx, cancel = context.WithCancel(context.Background())
+			input = make(chan entity.PipelineJob)
+			errs = make(chan entity.PipelineError, 10)
+			getErrors = drainErrors(errs)
+		})
+
+		AfterEach(func() {
+			cancel()
+		})
+
+		It("should succeed without retry when no error occurs", func() {
+			var callCount int
+			p := pipeline.NewPipeline[testInput, testOutput](
+				"test",
+				func(_ context.Context, in testInput) (testOutput, error) {
+					callCount++
+					return testOutput{Result: in.Value}, nil
+				},
+				func(_ context.Context, _ testOutput) error { return nil },
+				input, errs,
+			).WithRetry(3, 0)
+			done := p.Start(ctx)
+
+			data, _ := json.Marshal(testInput{Value: "hello"})
+			job := entity.NewPipelineJob(data)
+			input <- job
+
+			Eventually(job.Done).Should(BeClosed())
+			Expect(callCount).To(Equal(1))
+			Expect(getErrors()).To(BeEmpty())
+
+			cancel()
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("should retry and succeed after transient failures", func() {
+			var callCount int
+			p := pipeline.NewPipeline[testInput, testOutput](
+				"test",
+				func(_ context.Context, in testInput) (testOutput, error) {
+					callCount++
+					if callCount < 3 {
+						return testOutput{}, errors.New("transient error")
+					}
+					return testOutput{Result: in.Value}, nil
+				},
+				func(_ context.Context, _ testOutput) error { return nil },
+				input, errs,
+			).WithRetry(3, 0)
+			done := p.Start(ctx)
+
+			data, _ := json.Marshal(testInput{Value: "hello"})
+			job := entity.NewPipelineJob(data)
+			input <- job
+
+			Eventually(job.Done).Should(BeClosed())
+			Expect(callCount).To(Equal(3))
+			Expect(getErrors()).To(BeEmpty())
+
+			cancel()
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("should return error after exhausting all retries", func() {
+			var callCount int
+			p := pipeline.NewPipeline[testInput, testOutput](
+				"test",
+				func(_ context.Context, _ testInput) (testOutput, error) {
+					callCount++
+					return testOutput{}, errors.New("persistent error")
+				},
+				func(_ context.Context, _ testOutput) error { return nil },
+				input, errs,
+			).WithRetry(3, 0)
+			done := p.Start(ctx)
+
+			data, _ := json.Marshal(testInput{Value: "hello"})
+			job := entity.NewPipelineJob(data)
+			input <- job
+
+			Eventually(job.Done).Should(BeClosed())
+			Expect(callCount).To(Equal(4)) // 1 initial + 3 retries
+			Eventually(func() []entity.PipelineError { return getErrors() }).Should(HaveLen(1))
+			Expect(getErrors()[0].Err.Error()).To(Equal("persistent error"))
+
+			cancel()
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("should stop retrying when context is cancelled", func() {
+			var callCount int
+			p := pipeline.NewPipeline[testInput, testOutput](
+				"test",
+				func(fnCtx context.Context, _ testInput) (testOutput, error) {
+					callCount++
+					if callCount == 1 {
+						cancel()
+					}
+					return testOutput{}, errors.New("will cancel")
+				},
+				func(_ context.Context, _ testOutput) error { return nil },
+				input, errs,
+			).WithRetry(3, 1000*time.Millisecond)
+			done := p.Start(ctx)
+
+			data, _ := json.Marshal(testInput{Value: "hello"})
+			job := entity.NewPipelineJob(data)
+			input <- job
+
+			Eventually(done).Should(BeClosed())
+			Expect(callCount).To(Equal(1))
+		})
+	})
+
 	Describe("sendError", func() {
 		It("should block until the error is acknowledged", func() {
 			input := make(chan entity.PipelineJob)


### PR DESCRIPTION
## Summary
- Implement `Pipeline.WithRetry(maxRetries, baseDelay)` with exponential backoff retry logic
- Retry respects context cancellation and logs each attempt with pipeline name, attempt number, and error
- Add default retry constants (`defaultMaxRetries=3`, `defaultRetryDelay=1s`) used by `registerPipeline`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipelines now support configurable retry handling (max retries and base delay), and default retry settings are applied during pipeline registration.
  * Retries automatically stop when processing succeeds, the retry limit is reached, or cancellation occurs.

* **Bug Fixes**
  * After retries are exhausted, pipeline errors now return the final observed processing error.

* **Tests**
  * Added test coverage for first-attempt success, retry-and-success, exhausted-retry error reporting, and early termination on context cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->