### PR TITLE
ECOPROJECT-5155 | migration-event-streamer: Elasticsearch TLS certificate verification disabled by default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type ElasticSearch struct {
 	Password              string   `debugmap:"hidden"`
 	Host                  string   `debugmap:"visible" default:"http://localhost:9200"`
 	Indexes               []string `debugmap:"visible"`
-	SSLInsecureSkipVerify bool     `debugmap:"sensitive" default:"true"`
+	SSLInsecureSkipVerify bool     `debugmap:"sensitive" default:"false"`
 	ResponseTimeout       string   `debugmap:"visible" default:"90s"`
 	DialTimeout           string   `debugmap:"visible" default:"1s"`
 }

--- a/internal/datastore/elastic/client.go
+++ b/internal/datastore/elastic/client.go
@@ -31,7 +31,7 @@ func NewElasticsearchClient(config config.ElasticSearch) (*elastic.Client, error
 			DialContext:           (&net.Dialer{Timeout: config.GetDialTimeout()}).DialContext,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: config.SSLInsecureSkipVerify,
-				MinVersion:         tls.VersionTLS11,
+				MinVersion:         tls.VersionTLS12,
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>
