### PR TITLE
ECOPROJECT-5158 | migration-event-streamer: OpenShift Deployment templates omit securityContext, resource limits, and probes

### DIFF
--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -49,16 +49,38 @@ objects:
           labels:
             app: migration-event-streamer
         spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: migration-event-streamer
               image: ${IMAGE_NAME}:${IMAGE_TAG}
               imagePullPolicy: Always
               command: ["/app/streamer"]
               args: ["run"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
               ports:
                 - name: metrics
                   containerPort: ${{STREAMER_METRICS_PORT}}
                   protocol: TCP
+              livenessProbe:
+                httpGet:
+                  path: /metrics
+                  port: metrics
+                initialDelaySeconds: 10
+                periodSeconds: 30
+              readinessProbe:
+                httpGet:
+                  path: /metrics
+                  port: metrics
+                initialDelaySeconds: 5
+                periodSeconds: 15
               env:
                 - name: STREAMER_KAFKA_BROKERS
                   valueFrom:


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Services now run with stronger container security settings, including non-root execution, disabled privilege escalation, read-only filesystems, and dropped Linux capabilities.
  * The default seccomp security profile is enforced.

* **Reliability**
  * Added HTTP liveness and readiness checks for the metrics endpoint.
  * Configured separate startup delays and polling intervals for health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->