### PR TITLE
ECOPROJECT-5160 | fix: pin container base images by digest, bump builder Go version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Builder container
-FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset AS builder
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:1.25.9@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e AS builder
 
 USER 0
 
@@ -12,7 +12,7 @@ COPY . .
 
 RUN GOCACHE=/gocache CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /streamer main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.8-1784702951@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef
 
 WORKDIR /app
 

--- a/Containerfile.producer
+++ b/Containerfile.producer
@@ -1,5 +1,5 @@
 # Builder container
-FROM docker.io/golang:1.24-bullseye as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -11,7 +11,7 @@ COPY . .
 USER 0
 RUN GOCACHE=/gocache CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /producer samples/producer/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.8-1784702951@sha256:b1e86b97028b8fcfb6d85f997c39e6b6b67496163ef8d80d243220a4918e8bef
 
 WORKDIR /app
 


### PR DESCRIPTION
Both Containerfiles pulled their base images by mutable tag rather than
@sha256 digest, so a registry compromise or tag re-point could silently
change the build output. Containerfile.producer's builder was also on Go
1.24, older than the go.mod directive (1.25.9).

Pin both FROM lines in each Containerfile by digest and move the producer
builder to registry.access.redhat.com/ubi9/go-toolset:1.25.9, matching the
main Containerfile and dropping the docker.io dependency.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
