### PR TITLE
ECOPROJECT-5161 | fix: GitHub workflow lacks least-privilege token permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Aviel Segev <asegev@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated end-to-end testing permissions to allow read-only access to pull request information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->