### PR TITLE
migrate from Elasticsearch v9 to OpenSearch v4 for AWS compatibility

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           podman pull docker.io/library/postgres:17
           podman pull docker.io/apache/kafka:4.3.1
-          podman pull docker.io/library/elasticsearch:8.7.1
+          podman pull docker.io/opensearchproject/opensearch:2.19.6
 
       - name: Run e2e tests
         run: |

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -53,7 +53,8 @@ func NewRunCommand(cfg *config.Configuration, version, gitCommit string) *cobra.
 
 			envTopic := namespace.Topic()
 
-			dt, err := createDatastore(cfg, routerInputTopic, envTopic)
+			ctx := context.Background()
+			dt, err := createDatastore(ctx, cfg, routerInputTopic, envTopic)
 			if err != nil {
 				return err
 			}
@@ -139,8 +140,8 @@ func registerElasticFlags(flagSet *pflag.FlagSet, cfg *config.Configuration, ind
 	flagSet.StringVar(&cfg.ElasticSearch.DialTimeout, "elastic-dial-timeout", cfg.ElasticSearch.DialTimeout, "Elasticsearch dial timeout")
 }
 
-func createDatastore(cfg *config.Configuration, routerInputTopic, envTopic string) (*datastore.Datastore, error) {
-	dt := datastore.NewDatastore().WithElasticRepository(cfg.ElasticSearch)
+func createDatastore(ctx context.Context, cfg *config.Configuration, routerInputTopic, envTopic string) (*datastore.Datastore, error) {
+	dt := datastore.NewDatastore().WithElasticRepository(ctx, cfg.ElasticSearch)
 
 	dt.WithKafkaConsumer("router", cfg.Kafka, routerInputTopic, fmt.Sprintf("consumer-group-%s", routerInputTopic))
 	dt.WithKafkaConsumer("dispatcher", cfg.Kafka, envTopic, fmt.Sprintf("consumer-group-%s", envTopic))

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.26.0
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/creasty/defaults v1.7.0
-	github.com/elastic/elastic-transport-go/v8 v8.9.0
-	github.com/elastic/go-elasticsearch/v9 v9.5.0
 	github.com/fatih/color v1.19.0
 	github.com/go-extras/cobraflags v0.0.0-20260116100222-f76efc9500d4
 	github.com/google/uuid v1.6.0
@@ -15,6 +13,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
 	github.com/opencontainers/runtime-spec v1.3.0
+	github.com/opensearch-project/opensearch-go/v4 v4.7.3
 	github.com/prometheus/client_golang v1.24.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -86,10 +86,6 @@ github.com/docker/go-connections v0.8.1 h1:JibmG5hULs5qXSr/cp/w3Pw5fZuStt4MOHMUE
 github.com/docker/go-connections v0.8.1/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/elastic/elastic-transport-go/v8 v8.9.0 h1:KeT/2P54F0xS0S8Y3Pf+tFDg4HmBgReQMB+BMz8dDAs=
-github.com/elastic/elastic-transport-go/v8 v8.9.0/go.mod h1:ssMTvNS2hwf7CaiGsRRsx4gQHFZ/jS/DkLcISxekWzc=
-github.com/elastic/go-elasticsearch/v9 v9.5.0 h1:ye9pnajcrSE2Fra0Q++nJsi09p2dJTaN6YXKz7LL7WU=
-github.com/elastic/go-elasticsearch/v9 v9.5.0/go.mod h1:EbZnYlTlbhNqRt98YW+QSM2SEKplN5o8J+G6d9STOVo=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
@@ -261,6 +257,8 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20260316125833-8a4db579f5c8 h1:
 github.com/opencontainers/runtime-tools v0.9.1-0.20260316125833-8a4db579f5c8/go.mod h1:DKDEfzxvRkoQ6n9TGhxQgg2IM1lY4aM0eaQP4e3oElw=
 github.com/opencontainers/selinux v1.15.1 h1:ERxeh5caJvCzNAKdI8WQbJmB1LDTn4BuaAg8wihLBpA=
 github.com/opencontainers/selinux v1.15.1/go.mod h1:LenyElirjUHszfxrjuFqC85HIeXZKumHcKMQtnaDlQQ=
+github.com/opensearch-project/opensearch-go/v4 v4.7.3 h1:JzETy7bYnnSDj4gueUh8t4EYBhs9rhKsgeVsoul77rA=
+github.com/opensearch-project/opensearch-go/v4 v4.7.3/go.mod h1:+iikkyLrVC8ZvyfKv2sua1Ze1LbpWL7eZe4IkHqNGtg=
 github.com/openshift/imagebuilder v1.2.21 h1:XX0tZVznWTxzYevvNVZ/0eeTzmgY6cfcT4/xjs5ToyU=
 github.com/openshift/imagebuilder v1.2.21/go.mod h1:+L09sXUQ0RPdCU1tmzKrfBhqMlYvZtaA3MHb7aTjVU8=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
@@ -362,6 +360,8 @@ github.com/vbauerster/cupwriter v0.0.4 h1:9sBPe0uXWLZuWQU5lqVbhyFlxX6c09asST/Yfa
 github.com/vbauerster/cupwriter v0.0.4/go.mod h1:IFyzS6Xis5dnBH/rdAhrnuzg3c+KkUqEN6yE8lhJlDw=
 github.com/vbauerster/mpb/v8 v8.15.2 h1:hyIM0fSQn98i/9jz9Z0dpqhXQoSssgDN+6yXDidAx9k=
 github.com/vbauerster/mpb/v8 v8.15.2/go.mod h1:HgpQPKfcWe3kbuGGPmi+jatHreMase5C3Fp5dpdAy0Q=
+github.com/wI2L/jsondiff v0.7.1 h1:Fg9+yj+1/x3UtPBJhR91TKEzRkrEEWcAcLbg9dzEaNM=
+github.com/wI2L/jsondiff v0.7.1/go.mod h1:yAt2W7U6Jd4HK0RA8DGSGk0zDtfEtOUUJVnH/xICpjo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -27,7 +27,7 @@ func NewDatastore() *Datastore {
 	}
 }
 
-func (d *Datastore) WithElasticRepository(esConfig config.ElasticSearch) *Datastore {
+func (d *Datastore) WithElasticRepository(ctx context.Context, esConfig config.ElasticSearch) *Datastore {
 	d.buildFns = append(d.buildFns, func() error {
 		if d.elasticRepo != nil {
 			return nil
@@ -36,7 +36,7 @@ func (d *Datastore) WithElasticRepository(esConfig config.ElasticSearch) *Datast
 		if err != nil {
 			return err
 		}
-		if err := d.createIndexes(elasticRepo, esConfig.Indexes); err != nil {
+		if err := d.createIndexes(ctx, elasticRepo, esConfig.Indexes); err != nil {
 			return fmt.Errorf("failed to create indexes: %v", err)
 		}
 		d.elasticRepo = elasticRepo
@@ -123,9 +123,9 @@ func (d *Datastore) MustHaveProducer(name string) *plannerEvents.KafkaProducer {
 	return p
 }
 
-func (d *Datastore) createIndexes(es *elastic.ElasticRepository, indexes []string) error {
+func (d *Datastore) createIndexes(ctx context.Context, es *elastic.ElasticRepository, indexes []string) error {
 	for _, idx := range indexes {
-		if err := es.CreateIndex(idx); err != nil {
+		if err := es.CreateIndex(ctx, idx); err != nil {
 			return err
 		}
 	}

--- a/internal/datastore/elastic/client.go
+++ b/internal/datastore/elastic/client.go
@@ -1,20 +1,21 @@
 package elastic
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/elastic/elastic-transport-go/v8/elastictransport"
-	"io"
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
-	elastic "github.com/elastic/go-elasticsearch/v9"
 	"github.com/kubev2v/migration-event-streamer/internal/config"
+	opensearch "github.com/opensearch-project/opensearch-go/v4"
+	opensearchapi "github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"go.uber.org/zap"
 )
 
-func NewElasticsearchClient(config config.ElasticSearch) (*elastic.Client, error) {
+func NewElasticsearchClient(config config.ElasticSearch) (*opensearchapi.Client, error) {
 	host := config.Host
 	if host != "" && !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
 		host = "https://" + host
@@ -23,37 +24,41 @@ func NewElasticsearchClient(config config.ElasticSearch) (*elastic.Client, error
 		host,
 	}
 
-	client, err := elastic.New(
-		elastic.WithAddresses(addresses...),
-		elastic.WithBasicAuth(config.Username, config.Password),
-		elastic.WithTransportOptions(
-			elastictransport.WithTransport(&http.Transport{
-				MaxIdleConnsPerHost:   10,
-				ResponseHeaderTimeout: config.GetResponseTimeout(),
-				DialContext: (&net.Dialer{
-					Timeout: config.GetDialTimeout(),
-				}).DialContext,
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: config.SSLInsecureSkipVerify,
-					MinVersion:         tls.VersionTLS12,
-				},
-			}),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize elasticsearch client %w", err)
+	// Clone DefaultTransport to preserve connection pooling, HTTP/2, and timeouts
+	tp := http.DefaultTransport.(*http.Transport).Clone()
+	tp.MaxIdleConnsPerHost = 10
+	tp.ResponseHeaderTimeout = config.GetResponseTimeout()
+	tp.DialContext = (&net.Dialer{
+		Timeout: config.GetDialTimeout(),
+	}).DialContext
+	tp.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: config.SSLInsecureSkipVerify,
+		MinVersion:         tls.VersionTLS12,
 	}
 
-	resp, err := client.Info()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get info from elasticsearch server: %w", err)
+	cfg := opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses: addresses,
+			Username:  config.Username,
+			Password:  config.Password,
+			Transport: tp,
+		},
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
 
-	data, _ := io.ReadAll(resp.Body)
-	zap.S().Infof("connected to elastic search: %s", string(data))
+	client, err := opensearchapi.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize opensearch client %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := client.Info(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get info from opensearch server: %w", err)
+	}
+
+	zap.S().Infof("connected to opensearch: version=%s, cluster=%s", resp.Version.Number, resp.ClusterName)
 
 	return client, nil
 }

--- a/internal/datastore/elastic/elastic.go
+++ b/internal/datastore/elastic/elastic.go
@@ -1,11 +1,12 @@
 package elastic
 
 import (
+	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/kubev2v/migration-event-streamer/internal/config"
 	"github.com/kubev2v/migration-event-streamer/internal/namespace"
+	opensearchapi "github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 )
 
 type ElasticRepository struct {
@@ -35,24 +36,25 @@ func (e *ElasticRepository) Assessment() AssessmentWriter           { return e.a
 func (e *ElasticRepository) UserAction() UserActionWriter           { return e.userAction }
 func (e *ElasticRepository) PartnerCustomer() PartnerCustomerWriter { return e.partnerCustomer }
 
-func (e *ElasticRepository) CreateIndex(name string) error {
+func (e *ElasticRepository) CreateIndex(ctx context.Context, name string) error {
 	fullName := fmt.Sprintf("%s_%s", e.base.indexPrefix, name)
-	res, err := e.base.client.Indices.Exists([]string{fullName})
-	if err != nil {
-		return fmt.Errorf("failed to check if index %s exists: %w", name, err)
-	}
-	if res.StatusCode == http.StatusOK {
-		_ = res.Body.Close()
+
+	// Check if index exists
+	_, err := e.base.client.Indices.Exists(ctx, opensearchapi.IndicesExistsReq{
+		Indices: []string{fullName},
+	})
+	if err == nil {
+		// Index exists
 		return nil
 	}
 
-	res, err = e.base.client.Indices.Create(fullName)
+	// Create index
+	_, err = e.base.client.Indices.Create(ctx, opensearchapi.IndicesCreateReq{
+		Index: fullName,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create index %s: %w", name, err)
 	}
-	if res.IsError() {
-		return fmt.Errorf("failed to create index %s: %w", name, err)
-	}
-	_ = res.Body.Close()
+
 	return nil
 }

--- a/internal/datastore/elastic/writer.go
+++ b/internal/datastore/elastic/writer.go
@@ -5,13 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 
-	"github.com/elastic/go-elasticsearch/v9/esapi"
 	"github.com/kubev2v/migration-event-streamer/internal/entity"
+	opensearchapi "github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"go.uber.org/zap"
-
-	elastic "github.com/elastic/go-elasticsearch/v9"
 )
 
 type Writer interface {
@@ -40,28 +37,22 @@ type PartnerCustomerWriter interface {
 }
 
 type baseWriter struct {
-	client      *elastic.Client
+	client      *opensearchapi.Client
 	indexPrefix string
 }
 
 func (b *baseWriter) write(ctx context.Context, index, id string, data []byte) error {
-	req := esapi.IndexRequest{
+	req := opensearchapi.IndexReq{
 		Index:      fmt.Sprintf("%s_%s", b.indexPrefix, index),
 		DocumentID: id,
 		Body:       bytes.NewReader(data),
 	}
-	res, err := req.Do(ctx, b.client)
+	res, err := b.client.Index(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to insert document %s: %w", id, err)
 	}
-	defer func() { _ = res.Body.Close() }()
 
-	if res.IsError() {
-		bodyBytes, _ := io.ReadAll(res.Body)
-		return fmt.Errorf("failed to index document %s: %s - %s", id, res.Status(), string(bodyBytes))
-	}
-
-	zap.S().Infow("successful write", "index", index, "document_id", id, "method", "overwrite")
+	zap.S().Infow("successful write", "index", index, "document_id", id, "method", "overwrite", "result", res.Result)
 	return nil
 }
 
@@ -76,24 +67,18 @@ func (b *baseWriter) upsert(ctx context.Context, index, id string, data []byte) 
 		return fmt.Errorf("failed to marshal upsert body: %w", err)
 	}
 
-	req := esapi.UpdateRequest{
+	req := opensearchapi.UpdateReq{
 		Index:      fmt.Sprintf("%s_%s", b.indexPrefix, index),
 		DocumentID: id,
 		Body:       bytes.NewReader(bodyJSON),
 	}
 
-	res, err := req.Do(ctx, b.client)
+	res, err := b.client.Update(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to upsert document %s: %w", id, err)
 	}
-	defer func() { _ = res.Body.Close() }()
 
-	if res.IsError() {
-		bodyBytes, _ := io.ReadAll(res.Body)
-		return fmt.Errorf("failed to upsert document %s: %s - %s", id, res.Status(), string(bodyBytes))
-	}
-
-	zap.S().Infow("successful write", "index", index, "document_id", id, "method", "upsert")
+	zap.S().Infow("successful write", "index", index, "document_id", id, "method", "upsert", "result", res.Result)
 	return nil
 }
 
@@ -120,47 +105,28 @@ func (b *baseWriter) updateByQuery(ctx context.Context, req UpdateByQueryRequest
 		return nil, fmt.Errorf("failed to marshal query body: %w", err)
 	}
 
-	updateReq := esapi.UpdateByQueryRequest{
-		Index:     []string{indexName},
-		Body:      bytes.NewReader(bodyJSON),
-		Conflicts: "proceed",
+	updateReq := opensearchapi.UpdateByQueryReq{
+		Indices: []string{indexName},
+		Body:    bytes.NewReader(bodyJSON),
+		Params: opensearchapi.UpdateByQueryParams{
+			Conflicts: "proceed",
+		},
 	}
 
-	res, err := updateReq.Do(ctx, b.client)
+	res, err := b.client.UpdateByQuery(ctx, updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute update by query: %w", err)
 	}
-	defer func() { _ = res.Body.Close() }()
 
-	if res.IsError() {
-		bodyBytes, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("update by query failed: %s - %s", res.Status(), string(bodyBytes))
-	}
-
-	var response struct {
-		Total    int64 `json:"total"`
-		Updated  int64 `json:"updated"`
-		Failures []struct {
-			Index string `json:"index"`
-			ID    string `json:"id"`
-			Cause struct {
-				Reason string `json:"reason"`
-			} `json:"cause"`
-		} `json:"failures"`
-	}
-
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
+	// Response is already parsed - use fields directly
 	result := &UpdateByQueryResult{
-		Total:    response.Total,
-		Updated:  response.Updated,
-		Failed:   int64(len(response.Failures)),
-		Failures: make([]UpdateFailure, 0, len(response.Failures)),
+		Total:    int64(res.Total),
+		Updated:  int64(res.Updated),
+		Failed:   int64(len(res.Failures)),
+		Failures: make([]UpdateFailure, 0, len(res.Failures)),
 	}
 
-	for _, f := range response.Failures {
+	for _, f := range res.Failures {
 		result.Failures = append(result.Failures, UpdateFailure{
 			Index:      f.Index,
 			DocumentID: f.ID,

--- a/test/e2e/infra/container.go
+++ b/test/e2e/infra/container.go
@@ -122,13 +122,14 @@ func (c *ContainerInfraManager) CreateKafkaTopics() error {
 }
 
 func (c *ContainerInfraManager) StartElasticsearch() error {
-	zap.S().Info("Starting Elasticsearch...")
+	zap.S().Info("Starting OpenSearch...")
 	_, err := c.runner.StartContainer(
 		NewContainerConfig(esContainerName, esImage).
 			WithPort(esPort, esPort).
 			WithEnvVar("discovery.type", "single-node").
-			WithEnvVar("xpack.security.enabled", "false").
-			WithEnvVar("ES_JAVA_OPTS", "-Xms512m -Xmx512m"),
+			WithEnvVar("plugins.security.disabled", "true").
+			WithEnvVar("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m").
+			WithEnvVar("DISABLE_INSTALL_DEMO_CONFIG", "true"),
 	)
 	if err != nil {
 		return err
@@ -142,7 +143,7 @@ func (c *ContainerInfraManager) StopElasticsearch() error {
 }
 
 func (c *ContainerInfraManager) waitForElasticsearch(timeout time.Duration) error {
-	zap.S().Info("Waiting for Elasticsearch to be ready...")
+	zap.S().Info("Waiting for OpenSearch to be ready...")
 	deadline := time.Now().Add(timeout)
 	client := &http.Client{Timeout: 2 * time.Second}
 	for time.Now().Before(deadline) {
@@ -150,13 +151,13 @@ func (c *ContainerInfraManager) waitForElasticsearch(timeout time.Duration) erro
 		if err == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				zap.S().Info("Elasticsearch is ready")
+				zap.S().Info("OpenSearch is ready")
 				return nil
 			}
 		}
 		time.Sleep(2 * time.Second)
 	}
-	return fmt.Errorf("elasticsearch did not become ready within %v", timeout)
+	return fmt.Errorf("opensearch did not become ready within %v", timeout)
 }
 
 func (c *ContainerInfraManager) StartPlanner() error {

--- a/test/e2e/infra/types.go
+++ b/test/e2e/infra/types.go
@@ -9,8 +9,8 @@ const (
 	kafkaImage         = "docker.io/apache/kafka:4.3.1"
 	kafkaPort          = 9092
 
-	esContainerName = "e2e-streamer-test-elasticsearch"
-	esImage         = "docker.io/library/elasticsearch:8.7.1"
+	esContainerName = "e2e-streamer-test-opensearch"
+	esImage         = "docker.io/opensearchproject/opensearch:2.19.6"
 	esPort          = 9200
 
 	plannerContainerName = "e2e-streamer-test-planner"

--- a/test/e2e/service/elasticsearch.go
+++ b/test/e2e/service/elasticsearch.go
@@ -2,13 +2,13 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/kubev2v/migration-event-streamer/internal/entity"
+	opensearch "github.com/opensearch-project/opensearch-go/v4"
+	opensearchapi "github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"go.uber.org/zap"
-	"io"
-
-	elastic "github.com/elastic/go-elasticsearch/v9"
 )
 
 const (
@@ -28,15 +28,17 @@ type UserActionDocument struct {
 }
 
 type ElasticsearchService struct {
-	client *elastic.Client
+	client *opensearchapi.Client
 }
 
 func NewElasticsearchService(address string) (*ElasticsearchService, error) {
-	client, err := elastic.NewClient(elastic.Config{
-		Addresses: []string{address},
+	client, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses: []string{address},
+		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create elasticsearch client: %w", err)
+		return nil, fmt.Errorf("failed to create opensearch client: %w", err)
 	}
 	return &ElasticsearchService{client: client}, nil
 }
@@ -51,29 +53,16 @@ func (s *ElasticsearchService) GetAssessment(id string) (*entity.Assessment, err
 }
 
 func (s *ElasticsearchService) getDocument(index, id string, target any) error {
-	res, err := s.client.Get(index, id)
+	ctx := context.Background()
+	res, err := s.client.Document.Get(ctx, opensearchapi.DocumentGetReq{
+		Index:      index,
+		DocumentID: id,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get document: %w", err)
 	}
-	defer func() { _ = res.Body.Close() }()
 
-	if res.IsError() {
-		return fmt.Errorf("elasticsearch returned %s", res.Status())
-	}
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
-
-	var hit struct {
-		Source json.RawMessage `json:"_source"`
-	}
-	if err := json.Unmarshal(body, &hit); err != nil {
-		return fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	return json.Unmarshal(hit.Source, target)
+	return json.Unmarshal(res.Source, target)
 }
 
 func (s *ElasticsearchService) GetUserAction(id string) (*UserActionDocument, error) {
@@ -99,37 +88,17 @@ func (s *ElasticsearchService) searchDocuments(index, field, value string) ([]js
 		return nil, fmt.Errorf("failed to marshal query: %w", err)
 	}
 
-	res, err := s.client.Search(
-		s.client.Search.WithIndex(index),
-		s.client.Search.WithBody(bytes.NewReader(queryJSON)),
-	)
+	ctx := context.Background()
+	res, err := s.client.Search(ctx, &opensearchapi.SearchReq{
+		Indices: []string{index},
+		Body:    bytes.NewReader(queryJSON),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to search: %w", err)
 	}
-	defer func() { _ = res.Body.Close() }()
 
-	if res.IsError() {
-		return nil, fmt.Errorf("search returned %s", res.Status())
-	}
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	var result struct {
-		Hits struct {
-			Hits []struct {
-				Source json.RawMessage `json:"_source"`
-			} `json:"hits"`
-		} `json:"hits"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	sources := make([]json.RawMessage, len(result.Hits.Hits))
-	for i, hit := range result.Hits.Hits {
+	sources := make([]json.RawMessage, len(res.Hits.Hits))
+	for i, hit := range res.Hits.Hits {
 		sources[i] = hit.Source
 	}
 	return sources, nil
@@ -181,14 +150,12 @@ func (s *ElasticsearchService) SearchUserActions(field, value string) ([]UserAct
 }
 
 func (s *ElasticsearchService) RefreshIndex(index string) error {
-	res, err := s.client.Indices.Refresh(s.client.Indices.Refresh.WithIndex(index))
+	ctx := context.Background()
+	_, err := s.client.Indices.Refresh(ctx, &opensearchapi.IndicesRefreshReq{
+		Index: []string{index},
+	})
 	if err != nil {
 		return fmt.Errorf("failed to refresh index %s: %w", index, err)
-	}
-	defer func() { _ = res.Body.Close() }()
-
-	if res.IsError() {
-		return fmt.Errorf("refresh index %s returned %s", index, res.Status())
 	}
 	return nil
 }


### PR DESCRIPTION
Replaced Elasticsearch client v9 with OpenSearch client v4 to fix
connection failures with AWS OpenSearch Service. Elasticsearch v9
client actively rejects OpenSearch with "the client noticed that the
server is not Elasticsearch" error.

Changes:
- Replace github.com/elastic/go-elasticsearch/v9 with opensearch-go/v4
- Update production client code to use opensearchapi
- Switch e2e tests to use opensearchproject/opensearch:2.19.6 image
- Simplify API calls using OpenSearch's parsed response types

This ensures compatibility with both AWS OpenSearch Service (production)
and OpenSearch containers (e2e tests).

Signed-off-by: Aviel Segev <asegev@redhat.com>
