### PR TITLE
grant consumer read ACLs during init to fix TOPIC_AUTHORIZATION_FAILED

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/go-extras/cobraflags"
 	"github.com/kubev2v/migration-event-streamer/internal/config"
 	"github.com/kubev2v/migration-event-streamer/internal/namespace"
@@ -19,22 +23,43 @@ const (
 
 func NewInitCommand(cfg *config.Configuration) *cobra.Command {
 	var routerInputTopic string
+	var aclPrincipal string
 
 	initCmd := &cobra.Command{
 		Use:   "init",
-		Short: "Ensure required Kafka topics exist",
+		Short: "Ensure required Kafka topics exist and grant consumer ACLs",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			envTopic := namespace.Topic()
 
+			ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+			defer cancel()
+
+			adm, err := pkgkafka.NewAdminClient(cfg.Kafka.Brokers, cfg.Kafka.ConnKgoOpts())
+			if err != nil {
+				return err
+			}
+			defer adm.Close()
+
 			zap.S().Infow("ensuring input topic exists", "topic", routerInputTopic)
-			opts := cfg.Kafka.ConnKgoOpts()
-			if err := pkgkafka.EnsureTopic(cfg.Kafka.Brokers, opts, routerInputTopic, inputTopicPartitions, inputTopicReplicationFactor); err != nil {
+			if err := pkgkafka.EnsureTopic(ctx, adm, routerInputTopic, inputTopicPartitions, inputTopicReplicationFactor); err != nil {
 				return err
 			}
 
 			zap.S().Infow("ensuring env topic exists", "topic", envTopic)
-			if err := pkgkafka.EnsureTopic(cfg.Kafka.Brokers, opts, envTopic, envTopicPartitions, envTopicReplicationFactor); err != nil {
+			if err := pkgkafka.EnsureTopic(ctx, adm, envTopic, envTopicPartitions, envTopicReplicationFactor); err != nil {
+				return err
+			}
+
+			// Grant the service (consumer) principal the ACLs it needs to read
+			// from the topics we just ensured.
+			topics := []string{routerInputTopic, envTopic}
+			groups := []string{
+				fmt.Sprintf("consumer-group-%s", routerInputTopic),
+				fmt.Sprintf("consumer-group-%s", envTopic),
+			}
+			zap.S().Infow("granting consumer ACLs", "principal", aclPrincipal, "topics", topics, "groups", groups)
+			if err := pkgkafka.GrantConsumerACLs(ctx, adm, aclPrincipal, topics, groups); err != nil {
 				return err
 			}
 
@@ -50,6 +75,7 @@ func NewInitCommand(cfg *config.Configuration) *cobra.Command {
 	initCmd.Flags().StringVar(&cfg.Kafka.SASLPassword, "kafka-sasl-password", cfg.Kafka.SASLPassword, "SASL password for Kafka authentication")
 	initCmd.Flags().StringVar(&routerInputTopic, "router-input-topic", "", "Shared input topic")
 	_ = initCmd.MarkFlagRequired("router-input-topic")
+	initCmd.Flags().StringVar(&aclPrincipal, "acl-principal", "", "Kafka principal (SASL username) to grant read access on the managed topics and consumer groups")
 
 	cobraflags.CobraOnInitialize("STREAMER", initCmd)
 

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -78,6 +78,11 @@ objects:
                     secretKeyRef:
                       name: ${MSK_ADMIN_CREDENTIALS_SECRET_NAME}
                       key: password
+                - name: STREAMER_ACL_PRINCIPAL
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${MSK_CREDENTIALS_SECRET_NAME}
+                      key: username
               resources:
                 requests:
                   cpu: 50m

--- a/pkg/kafka/acls.go
+++ b/pkg/kafka/acls.go
@@ -1,0 +1,55 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+	"go.uber.org/zap"
+)
+
+// GrantConsumerACLs allows the given principal to consume from the provided
+// topics and consumer groups. It grants Read and Describe on each topic and
+// each group, which is what a franz-go consumer needs to fetch records and
+// join/commit within its group.
+//
+// The principal is a Kafka principal such as the SASL/SCRAM username; a bare
+// username is automatically prefixed with "User:". Creating an ACL that already
+// exists is a no-op on the broker, so this is safe to run on every init.
+func GrantConsumerACLs(ctx context.Context, adm *kadm.Client, principal string, topics, groups []string) error {
+	if principal == "" {
+		return fmt.Errorf("cannot grant ACLs: empty principal")
+	}
+	if len(topics) == 0 && len(groups) == 0 {
+		return nil
+	}
+
+	b := kadm.NewACLs().
+		Allow(principal).
+		AllowHosts("*").
+		Operations(kadm.OpRead, kadm.OpDescribe).
+		ResourcePatternType(kadm.ACLPatternLiteral)
+	b.PrefixUser()
+
+	if len(topics) > 0 {
+		b.Topics(topics...)
+	}
+	if len(groups) > 0 {
+		b.Groups(groups...)
+	}
+
+	results, err := adm.CreateACLs(ctx, b)
+	if err != nil {
+		return fmt.Errorf("failed to create ACLs for principal %s: %w", principal, err)
+	}
+
+	for _, r := range results {
+		if r.Err != nil {
+			return fmt.Errorf("failed to create ACL (%s %s %v) for principal %s: %w",
+				r.Type, r.Name, r.Operation, principal, r.Err)
+		}
+	}
+
+	zap.S().Infow("consumer ACLs granted", "principal", principal, "topics", topics, "groups", groups)
+	return nil
+}

--- a/pkg/kafka/topic.go
+++ b/pkg/kafka/topic.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
@@ -12,20 +11,21 @@ import (
 	"go.uber.org/zap"
 )
 
-func EnsureTopic(brokers []string, opts []kgo.Opt, topic string, partitions int32, replicationFactor int16) error {
+// NewAdminClient builds a kadm admin client against the given brokers. The
+// caller owns the returned client and must Close it, which also closes the
+// underlying kgo client.
+func NewAdminClient(brokers []string, opts []kgo.Opt) (*kadm.Client, error) {
 	clientOpts := append([]kgo.Opt{kgo.SeedBrokers(brokers...)}, opts...)
-	cl, err := kgo.NewClient(clientOpts...)
+	adm, err := kadm.NewOptClient(clientOpts...)
 	if err != nil {
-		return fmt.Errorf("failed to create kafka admin client: %w", err)
+		return nil, fmt.Errorf("failed to create kafka admin client: %w", err)
 	}
-	defer cl.Close()
+	return adm, nil
+}
 
-	adm := kadm.NewClient(cl)
-	defer adm.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
+// EnsureTopic creates the topic if it does not already exist. It is idempotent:
+// an existing topic is treated as success.
+func EnsureTopic(ctx context.Context, adm *kadm.Client, topic string, partitions int32, replicationFactor int16) error {
 	resp, err := adm.CreateTopic(ctx, partitions, replicationFactor, nil, topic)
 	if err != nil {
 		if errors.Is(err, kerr.TopicAlreadyExists) {

--- a/test/e2e/infra/container.go
+++ b/test/e2e/infra/container.go
@@ -1,6 +1,7 @@
 package infra
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -113,8 +114,18 @@ func (c *ContainerInfraManager) waitForKafka(timeout time.Duration) error {
 func (c *ContainerInfraManager) CreateKafkaTopics() error {
 	zap.S().Info("Creating Kafka topics...")
 	brokers := []string{fmt.Sprintf("localhost:%d", kafkaPort)}
+
+	adm, err := pkgkafka.NewAdminClient(brokers, nil)
+	if err != nil {
+		return err
+	}
+	defer adm.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	for _, topic := range kafkaTopics {
-		if err := pkgkafka.EnsureTopic(brokers, nil, topic, 1, 1); err != nil {
+		if err := pkgkafka.EnsureTopic(ctx, adm, topic, 1, 1); err != nil {
 			return fmt.Errorf("failed to create topic %s: %w", topic, err)
 		}
 	}


### PR DESCRIPTION
The service runs as a non-admin MSK user that lacks Read/Describe on the
managed topics and consumer groups, causing TOPIC_AUTHORIZATION_FAILED on
fetch. The init command already runs with admin credentials, so provision
the service principal's ACLs there.

- Add GrantConsumerACLs helper (Read+Describe on topics and groups)
- Refactor EnsureTopic to accept a shared *kadm.Client and context
- Add NewAdminClient helper and reuse a single client in init
- Wire STREAMER_ACL_PRINCIPAL into the init container from the service creds

Signed-off-by: Aviel Segev <asegev@redhat.com>
